### PR TITLE
Fix deconstruct nil panic

### DIFF
--- a/clients/mythic/mythic.go
+++ b/clients/mythic/mythic.go
@@ -641,25 +641,22 @@ func (client *Client) Deconstruct(data []byte) (returnMessages []messages.Base, 
 	for _, t := range client.transformers {
 		var ret any
 		if t.String() == "mythic" {
-			ret, err = t.Deconstruct(data, client.secret)
-			if err != nil {
-				err = fmt.Errorf("there was an error transforming the Mythic message:\n%s", err)
-				return
-			}
-			byteData, ok := ret.([]byte)
-			if !ok || byteData == nil {
-				err = fmt.Errorf("transformer %s returned unexpected type or nil", t.String())
-				return
-			}
-			data = byteData
+			ret, err = t.Deconstruct(data, []byte(client.MythicID.String()))
 		} else {
 			ret, err = t.Deconstruct(data, client.secret)
-			data = ret.([]byte)
 		}
+
 		if err != nil {
 			err = fmt.Errorf("there was an error transforming the Mythic message:\n%s", err)
 			return
 		}
+
+		byteData, ok := ret.([]byte)
+		if !ok || byteData == nil {
+			err = fmt.Errorf("transformer %s returned unexpected type or nil", t.String())
+			return
+		}
+		data = byteData
 	}
 
 	cli.Message(cli.DEBUG, fmt.Sprintf("Decrypted JSON:\n%s", data))

--- a/clients/mythic/mythic.go
+++ b/clients/mythic/mythic.go
@@ -641,8 +641,17 @@ func (client *Client) Deconstruct(data []byte) (returnMessages []messages.Base, 
 	for _, t := range client.transformers {
 		var ret any
 		if t.String() == "mythic" {
-			ret, err = t.Deconstruct(data, []byte(client.MythicID.String()))
-			data = ret.([]byte)
+			ret, err = t.Deconstruct(data, client.secret)
+			if err != nil {
+				err = fmt.Errorf("there was an error transforming the Mythic message:\n%s", err)
+				return
+			}
+			byteData, ok := ret.([]byte)
+			if !ok || byteData == nil {
+				err = fmt.Errorf("transformer %s returned unexpected type or nil", t.String())
+				return
+			}
+			data = byteData
 		} else {
 			ret, err = t.Deconstruct(data, client.secret)
 			data = ret.([]byte)


### PR DESCRIPTION
### Change Type
- [ ] Addition
- [x] Bugfix
- [ ] Modification
- [ ] Removal
- [ ] Security

### Description

Fixes a runtime panic in the `Deconstruct()` method of the Mythic client where a transformer could return `nil`, leading to an unsafe type assertion (`interface{} is nil, not []uint8`).

This change introduces proper type-checking after each call to `t.Deconstruct()`, including the `"mythic"` transformer path. If the returned value is `nil` or not of type `[]byte`, the function now returns an error instead of panicking.

This improves agent stability when receiving unexpected or malformed data from the Mythic C2 server.